### PR TITLE
Corrected release environment url

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/<your-pypi-project-name>
+      url: https://pypi.org/project/gddoc2yml/
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:


### PR DESCRIPTION
Corrected environment url to be `https://pypi.org/project/gddoc2yml/`